### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 A Model Context Protocol (MCP) server implementation for accessing eRegulations API data. This server provides structured, AI-friendly access to eRegulations instances, making it easier for AI models to answer user questions about administrative procedures.
 
+<a href="https://glama.ai/mcp/servers/@unctad-ai/eregulations-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@unctad-ai/eregulations-mcp-server/badge" alt="eRegulations Server MCP server" />
+</a>
+
 ## Features
 
 - Access eRegulations data through a standardized protocol
@@ -134,4 +138,4 @@ npm run test:watch
 
 # Run test client
 npm run test-client
-````
+```


### PR DESCRIPTION
This PR adds a badge for the [eRegulations MCP Server](https://glama.ai/mcp/servers/@unctad-ai/eregulations-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@unctad-ai/eregulations-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@unctad-ai/eregulations-mcp-server/badge" alt="eRegulations Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.